### PR TITLE
Fix self.frame is null

### DIFF
--- a/MainFrame.lua
+++ b/MainFrame.lua
@@ -122,6 +122,10 @@ function StriLi.MainFrame:hide()
 end
 
 function StriLi.MainFrame:toggle()
+	
+    if self.frame == nil then
+        self:init();
+    end
 
     if (self.frame:IsVisible()) then
         self:hide();


### PR DESCRIPTION
In case that `init()` wasn't called `self.frame` is null. Fixing the nullpointer for `self.frame:IsVisible()` by checking if frame is null, if yes then call init.

Not sure when/how normally `init()` is expected to be called. That is just my fix for the problem.

```lua
1x StriLi\MainFrame.lua:130: attempt to index field 'frame' (a nil value)
[string "@StriLi\MainFrame.lua"]:130: in function `toggle'
[string "@StriLi\Core.lua"]:6: in function `OnClick'
[string "@AtlasLootClassic\Libs\LibDBIcon-1.0\LibDBIcon-1.0-44.lua"]:144: in function <...tlasLootClassic\Libs\LibDBIcon-1.0\LibDBIcon-1.0.lua:142>

Locals:
self = <table> {
 addPlayer = <function> defined @StriLi\MainFrame.lua:195
 setupLabelRow = <function> defined @StriLi\MainFrame.lua:138
 rows = <table> {
 }
 OnClickSyncButton = <function> defined @StriLi\MainFrame.lua:292
 removePlayer = <function> defined @StriLi\MainFrame.lua:228
 sortRowFrames = <function> defined @StriLi\MainFrame.lua:431
 nameTable = <table> {
 }
 toggle = <function> defined @StriLi\MainFrame.lua:124
 sortByClass = <function> defined @StriLi\MainFrame.lua:535
 children = <table> {
 }
 hide = <function> defined @StriLi\MainFrame.lua:120
 combineMembers = <function> defined @StriLi\MainFrame.lua:278
 OnClickLockButton = <function> defined @StriLi\MainFrame.lua:313
 OnMasterChanged = <function> defined @StriLi\MainFrame.lua:405
 init = <function> defined @StriLi\MainFrame.lua:62
 resetData = <function> defined @StriLi\MainFrame.lua:398
 initDropdownMenu = <function> defined @StriLi\MainFrame.lua:344
 rowCount = 0
 sortType = <table> {
 }
 show = <function> defined @StriLi\MainFrame.lua:116
 sortByCounter = <function> defined @StriLi\MainFrame.lua:509
 OnValueChanged = <function> defined @StriLi\MainFrame.lua:268
 sortByName = <function> defined @StriLi\MainFrame.lua:491
 OnClickResetButton = <function> defined @StriLi\MainFrame.lua:296
 OnClickSortButton = <function> defined @StriLi\MainFrame.lua:331
 reIndexFrames = <function> defined @StriLi\MainFrame.lua:260
 resize = <function> defined @StriLi\MainFrame.lua:253
}
(*temporary) = nil
(*temporary) = nil
(*temporary) = "attempt to index field 'frame' (a nil value)"
```